### PR TITLE
mentDelete.js 구현 및 mentRead.js issues 확인하여 처리

### DIFF
--- a/public/js/create.js
+++ b/public/js/create.js
@@ -75,7 +75,7 @@ function saveBoard(e){
         content     : content.value,
         regiDate    : getToday(),
         parentId    : uniquekey
-        
+    
     }
     
     //Transaction : localStorage를 가져와서 createRowData를 push하고 JSON으로 다시 밀어넣는다.

--- a/public/js/mentDelete.js
+++ b/public/js/mentDelete.js
@@ -1,0 +1,28 @@
+const deletebutton = document.querySelector(".delete-btn");
+const deleteBtn = (e) => {
+    if(e.target.className !== "delete-btn") return;
+    
+    const dbTableBoards = JSON.parse(localStorage.getItem("dbTableBoard")) || [];
+    const request = new URLSearchParams(location.search);
+    const index = request.get("index");
+
+    const replyData = JSON.parse(localStorage.getItem("replyData")) || [];
+    const replyId = Number(e.target.parentNode.dataset.key);
+    const replyIndex = Number(e.target.parentNode.dataset.index);
+
+    const cheakConfirm = confirm(`댓글을 삭제 하시겠습니까?`)
+    if(!cheakConfirm) {return};
+    
+    for(let i = 0; i < replyData.length; i++) {
+       if(replyData[i].replyId === replyId) {
+            replyData.splice(replyIndex, 1);
+            break;
+       }
+
+    }
+
+    localStorage.setItem("replyData", JSON.stringify(replyData));
+    window.location.href = `./view.html?appKind=detail&userId=${dbTableBoards[index].userId}&index=${index}&uniquekey=${dbTableBoards[index].parentId}`
+}
+
+mentAreaList.addEventListener("click", deleteBtn)

--- a/public/js/mentRead.js
+++ b/public/js/mentRead.js
@@ -4,11 +4,14 @@ const mentRead = () => {
     const replyDate = JSON.parse(localStorage.getItem("replyData")) || [];
     const request = new URLSearchParams(location.search);
     const key = Number(request.get("uniquekey"));
+    const loginData = JSON.parse(localStorage.getItem('loginUserData'));
+    const loginUserId = loginData.userId;
     
     for (let i = 0; i < replyDate.length; i++) {
         if (key === replyDate[i].parentId) {
             const commentLi = document.createElement("li");
-            commentLi.setAttribute("class", "commentlist")
+            commentLi.setAttribute("class", "commentlist");
+            commentLi.setAttribute("data-index", i);
             commentLi.setAttribute("data-key", replyDate[i].replyId);
 
             const commentId = document.createElement("p");
@@ -16,19 +19,26 @@ const mentRead = () => {
 
             const commentCt = document.createElement("p");
             commentCt.textContent = `${replyDate[i].mentContent}`;
+            
+ 
+            if (loginUserId === replyDate[i].mentUserId) {
 
-            const commentDB = document.createElement("button");
-            commentDB.setAttribute("class", "delete-btn");
-            commentDB.setAttribute("onclick" , "deleteBtn()");
-            commentDB.textContent = `삭제`;
+                const commentDB = document.createElement("button");
+                commentDB.setAttribute("class", "delete-btn");
+                commentDB.textContent = `삭제`;
 
-            const commentUP = document.createElement("button");
-            commentUP.setAttribute("class", "update-btn");
-            commentUP.setAttribute("onclick", "updateBtn()");
-            commentUP.textContent = `수정`;
+                const commentUP = document.createElement("button");
+                commentUP.setAttribute("class", "update-btn");
+                commentUP.setAttribute("onclick", "updateBtn()");
+                commentUP.setAttribute("type", "button");
+                commentUP.textContent = `수정`;
+                mentAreaList.appendChild(commentLi);
+                commentLi.append(commentId,commentCt,commentDB,commentUP);
+            }else{
+                mentAreaList.appendChild(commentLi);
+                commentLi.append(commentId,commentCt);
+            }
 
-            mentAreaList.appendChild(commentLi);
-            commentLi.append(commentId,commentCt,commentDB,commentUP);
             }
     }
 }

--- a/public/js/mentRead.js
+++ b/public/js/mentRead.js
@@ -9,7 +9,7 @@ const mentRead = () => {
         if (key === replyDate[i].parentId) {
             const commentLi = document.createElement("li");
             commentLi.setAttribute("class", "commentlist")
-            commentLi.setAttribute("data-key", replyDate[i].parentId);
+            commentLi.setAttribute("data-key", replyDate[i].replyId);
 
             const commentId = document.createElement("p");
             commentId.textContent = `${replyDate[i].mentUserId}`

--- a/view.html
+++ b/view.html
@@ -49,6 +49,7 @@
     </div>
     <script src="./public/js/comment.js"></script>
     <script src="./public/js/mentRead.js"></script>
+    <script src="./public/js/mentDelete.js"></script>
     <script src="./public/js/delete.js"></script>
     <script src="./public/js/update.js"></script>
     <script src="./public/js/detail.js"></script>


### PR DESCRIPTION
mentDelete.js 에서 정상적으로 원하는 댓글만 삭제할 수 있도록 구현

mentRead.js에서 li 생성시에 data-key값을 할당 하도록 하여 추후 삭제에서 target의 parentNode로 dataset을 찾아
특정한 자식키만 삭제할 수 있도록 구현하였습니다.

또한 issues에서 언급된 `로그인 유저정보 가져오기 ` 항목 부분 처리하였으니 확인해주시길 바랍니다.
