### PR TITLE
fix: 상세페이지 버튼명 수정 - 뒤로가기 -> 목록으로

### DIFF
--- a/view.html
+++ b/view.html
@@ -29,7 +29,7 @@
             </div>
             <div class="btnArea">
                 <div class="btnArea-left">
-                    <button class="btnGoBack" onclick="window.location.href = `./list.html`;" name="goBack" type="button" >뒤로가기</button> 
+                    <button class="btnGoBack" onclick="location.href = `./list.html`" name="goBack" type="button" >목록으로</button> 
                     <button class="btnUpdate" name="updateMode" type="button" value="updateMode">수정모드</button> 
                     <button class="btnDelete" name="delete" type="button" value="del">삭제</button> 
                 </div>


### PR DESCRIPTION
### 버튼명 : `뒤로가기` -> `목록으로`
* 사유 : 기존엔 `뒤로가기`가 목록 밖에 없었으나  
댓글 수정 페이지가 추가됨으로서 원치 않는 페이지 이동 될 가능성 생김
```html
history.back() -> href="./list.html" 
```
<img width="703" height="395" alt="image" src="https://github.com/user-attachments/assets/c41ee7ec-1027-4652-8db1-8f4ea3b5880a" />
